### PR TITLE
chrome.notifications default is to close on click

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -47,13 +47,6 @@ function setupNotification(timer) {
       message: timer.desc,
       iconUrl: "128.png"
     }, function() {
-      chrome.notifications.onClicked.addListener(function(notificationId) {
-        if (notificationId === id) {
-          chrome.notifications.clear(id, function() {
-            console.log(id + ": closed at " + new Date().toString());
-          });
-        }
-      });
       chrome.storage.local.get({soundType: "tts", soundId: "ring"}, function(object) {
         if (object.soundType == "tts") {
           chrome.tts.speak(timer.desc);


### PR DESCRIPTION
This patch removes our logic to close notifications on click because that is
already the default behavior of the chrome.notifications API.
