### PR TITLE
avoid 5-sec dismissal with window.Notification API

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -29,11 +29,11 @@ function parseTime(str) {
 }
 
 function setupNotification(timer) {
-  if (!chrome.notifications) {
+  if (!window.Notification) {
     return;
   }
 
-  var id = String(timer.id);
+  var id = timer.id;
   var ms = timer.seconds * 1000;
   var title = 'Timer done!';
 
@@ -41,28 +41,25 @@ function setupNotification(timer) {
               + timer.currentTime);
 
   setTimeout(function() {
-    chrome.notifications.create(id, {
-      type: "basic",
-      title: title,
-      message: timer.desc,
-      iconUrl: "128.png"
-    }, function() {
-      chrome.notifications.onClicked.addListener(function(notificationId) {
-        if (notificationId === id) {
-          chrome.notifications.clear(id, function() {
-            console.log(id + ": closed at " + new Date().toString());
-          });
-        }
-      });
-      chrome.storage.local.get({soundType: "tts", soundId: "ring"}, function(object) {
-        if (object.soundType == "tts") {
-          chrome.tts.speak(timer.desc);
-        } else {
-          audios[object.soundId].play();
-        }
-      });
-      console.log(id + ": notified at " + new Date().toString());
+    var notification = new window.Notification(title, {
+      tag: id,
+      icon: "48.png",
+      body: timer.desc
     });
+    notification.addEventListener('click', function(e) {
+      if (e && e.target && e.target.close) {
+        e.target.close();
+      }
+      console.log(id + ": closed at " + new Date().toString());
+    });
+    chrome.storage.local.get({soundType: "tts", soundId: "ring"}, function(object) {
+      if (object.soundType == "tts") {
+        chrome.tts.speak(timer.desc);
+      } else {
+        audios[object.soundId].play();
+      }
+    });
+    console.log(id + ": notified at " + new Date().toString());
   }, ms);
 }
 


### PR DESCRIPTION
After using GH-7 for a week now, I observe that the chrome.notifications API
automatically hides the timer notice after 5 seconds whereas the old 
webkit.notifications and the new window.Notification APIs do not.

I prefer the latter behavior because I want the timer notice to be visible 
until _I manually_ dismiss it.  For example, I might look away from my 
computer for a moment (and thereby miss the timer notice) and return to using
my computer while thinking that the timer is still in progress.

So this commit updates this extension to use the window.Notification API.
