### PR TITLE
history call failure

### DIFF
--- a/src/chrome.js
+++ b/src/chrome.js
@@ -1,5 +1,3 @@
-// Store history
-var history = History()
 resetDefaultSuggestion();
 
 chrome.omnibox.onInputEntered.addListener(function(text){
@@ -10,7 +8,7 @@ chrome.omnibox.onInputEntered.addListener(function(text){
 
     // Store history when a timer is set
     if (result) {
-      history.add(text);
+      History().add(text);
     }
   }
 });
@@ -40,9 +38,9 @@ chrome.omnibox.onInputChanged.addListener(function(text, suggest) {
   chrome.storage.local.get({historySuggestionType: "time"}, function(object) {
     var suggestions = [];
     if (object.historySuggestionType === "time") {
-      var founds = history.findByTime(text);
+      var founds = History().findByTime(text);
     } else {
-      var founds = history.findByCount(text);
+      var founds = History().findByCount(text);
     }
     for (var i = 0; i < founds.length; i++) {
       var found = founds[i];


### PR DESCRIPTION
![errorfunctionhistorycall](https://cloud.githubusercontent.com/assets/7820699/23863930/6ea4d666-07e7-11e7-8ee9-cc229a224b1d.png)

I'm getting :
* history.findByTime is not a function
* history.add is not a function

I found that error by opening the debug view in google chrome:
* go to extensions
* find Omnibox Timer
* Find inspect views
* Click on background page

A similar error is described in this link: 
http://stackoverflow.com/questions/6317845/javascript-is-not-a-function-error-when-calling-defined-method

Solution: the solution is to merge my fixes

also ... Thank you for pushing the new version of timer! :D